### PR TITLE
增加编辑本地聊天记录的功能

### DIFF
--- a/src/views/chat/components/Message/index.vue
+++ b/src/views/chat/components/Message/index.vue
@@ -24,6 +24,7 @@ interface Props {
 interface Emit {
   (ev: 'regenerate'): void
   (ev: 'delete'): void
+  (ev: 'edit'): void
 }
 
 const props = defineProps<Props>()
@@ -54,6 +55,11 @@ const options = computed(() => {
       key: 'delete',
       icon: iconRender({ icon: 'ri:delete-bin-line' }),
     },
+    {
+      label: t('common.edit'),
+      key: 'edit',
+      icon: iconRender({ icon: 'ri:edit-2-line' }),
+    },
   ]
 
   if (!props.inversion) {
@@ -72,7 +78,7 @@ const options = computed(() => {
   return common
 })
 
-function handleSelect(key: 'copyText' | 'delete' | 'toggleRenderType' |'tts') {
+function handleSelect(key: 'copyText' | 'delete' | 'edit' | 'toggleRenderType' | 'tts') {
   switch (key) {
     case 'tts': 
       homeStore.setMyData({act:'gpt.ttsv2', actData:{ index:props.index , uuid:props.chat.uuid, text:props.text } });
@@ -85,6 +91,9 @@ function handleSelect(key: 'copyText' | 'delete' | 'toggleRenderType' |'tts') {
       return
     case 'delete':
       emit('delete')
+      return
+    case 'edit':
+      emit('edit')
   }
 }
 

--- a/src/views/chat/index.vue
+++ b/src/views/chat/index.vue
@@ -1,8 +1,6 @@
-
-
 <script setup lang='ts'>
 import type { Ref } from 'vue'
-import { computed, onMounted, onUnmounted, ref,watch,h } from 'vue'
+import { computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { NAutoComplete, NButton, NInput, useDialog, useMessage,NAvatar } from 'naive-ui'
@@ -384,6 +382,35 @@ function handleDelete(index: number) {
   })
 }
 
+function handleEdit(index: number) {
+  if (loading.value)
+    return
+
+  const editedMessage = ref(dataSources.value[index].text.slice())
+
+  const inputNode = () => {
+    return h(NInput, {
+      'value': editedMessage.value,
+      'type': 'textarea',
+      'autosize': { minRows: 1, maxRows: 8 },
+      'showCount': true,
+      'onUpdate:value': (v: string) => {
+        editedMessage.value = v
+      },
+    })
+  }
+
+  dialog.warning({
+    title: t('common.edit'),
+    content: inputNode,
+    positiveText: t('common.yes'),
+    negativeText: t('common.no'),
+    onPositiveClick: () => {
+      updateChatSome(+uuid, index, { text: editedMessage.value })
+    },
+  })
+}
+
 function handleClear() {
   if (loading.value)
     return
@@ -575,6 +602,7 @@ const ychat = computed( ()=>{
                 :loading="item.loading"
                 @regenerate="onRegenerate(index)"
                 @delete="handleDelete(index)"
+                @edit="handleEdit(index)"
                 :chat="item"
                 :index="index"
               />


### PR DESCRIPTION
通过编辑聊天记录可以绕过gemini的部分限制
例如gemini回复`抱歉，我不应该产生本质上具有性暗示的反应。你想让我尝试生成一些不同的东西吗？`时，可以手动将回复修改掉，这样就能继续对话了。
![image](https://github.com/Dooy/chatgpt-web-midjourney-proxy/assets/52437374/6d27e4b4-a360-44b8-b251-06a6a71b9392)

![image](https://github.com/Dooy/chatgpt-web-midjourney-proxy/assets/52437374/bb1e5447-fed4-42d1-b2b1-49d667d0ed07)

![image](https://github.com/Dooy/chatgpt-web-midjourney-proxy/assets/52437374/e4617b72-2684-427e-878d-f972b6c77cdd)
