### PR TITLE
Midjourney Proxy v2.5.5 API后端不接受 index为0的重绘提交

### DIFF
--- a/src/views/mj/mjText.vue
+++ b/src/views/mj/mjText.vue
@@ -257,7 +257,7 @@ load();
                     <NButton type="warning" @click="sub('VARIATION',2)"  size="small">V2</NButton>
                     <NButton type="warning" @click="sub('VARIATION',3)"  size="small">V3</NButton>
                     <NButton type="warning" @click="sub('VARIATION',4)"  size="small">V4</NButton>
-                    <NButton type="warning" @click="sub('REROLL',0)"  size="small" v-if="chat.opt?.action==='IMAGINE'">{{ $t('mjchat.reroll') }}</NButton>
+                    <NButton type="warning" @click="sub('REROLL',1)"  size="small" v-if="chat.opt?.action==='IMAGINE'">{{ $t('mjchat.reroll') }}</NButton>
 
                 </div>
             </template>


### PR DESCRIPTION
使用的proxy版本：Midjourney Proxy v2.5.5

后端不接受 action REROLL 的index为非1、2、3、4
![1709809564586](https://github.com/Dooy/chatgpt-web-midjourney-proxy/assets/36898061/15f7cc41-6852-42a7-860b-861c97ee9258)


修改后可正常提交重绘
![1709809505912](https://github.com/Dooy/chatgpt-web-midjourney-proxy/assets/36898061/449377d3-2d30-40aa-8061-ffeb7e27a671)


