### PR TITLE
💄 优化文件上传样式

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -581,7 +581,6 @@ export const getHistoryMessage= async (dataSources:Chat.Chat[],loadingCnt=1 ,sta
                let fileBase64= JSON.parse(str) as string[];
                let arr =  fileBase64.filter( (ff:string)=>ff.indexOf('http')>-1);
                if(arr.length>0) content = arr.join(' ')+' '+ content ;
-
                mlog(t('mjchat.attr') ,o.opt.images[0] , content );
             }catch(ee){
             }

--- a/src/views/mj/aiGpt.vue
+++ b/src/views/mj/aiGpt.vue
@@ -71,7 +71,7 @@ watch(()=>homeStore.myData.act, async (n)=>{
             if( !canVisionModel(model)  )  model= canBase64Model(model)//model='gpt-4-vision-preview';
         
             try{
-                    let images= await localSaveAny( JSON.stringify( dd.fileBase64)  ) ;
+                    let images= await localSaveAny( JSON.stringify({fileName: dd.fileName, fileBase64: dd.fileBase64 }) ) ;
                     mlog('key', images );
                     promptMsg.opt= {images:[images]}
             }catch(e){

--- a/src/views/mj/aiGptInput.vue
+++ b/src/views/mj/aiGptInput.vue
@@ -24,7 +24,7 @@ const chatStore = useChatStore()
 const emit = defineEmits(['update:modelValue'])
 const props = defineProps<{ modelValue:string,disabled?:boolean,searchOptions?:AutoCompleteOptions,renderOption?: RenderLabel }>();
 const fsRef = ref()
-const st = ref<{fileBase64:string[],isLoad:number,isShow:boolean,showMic:boolean,micStart:boolean}>({fileBase64:[],isLoad:0
+const st = ref<{fileBase64:string[],fileName:string[],isLoad:number,isShow:boolean,showMic:boolean,micStart:boolean}>({fileBase64:[],fileName:[],isLoad:0
     ,isShow:false,showMic:false , micStart:false})
 const { isMobile } = useBasicLayout()
 const placeholder = computed(() => {
@@ -50,11 +50,13 @@ const handleSubmit = ( ) => {
     }
     let obj={
         prompt: mvalue.value,
-        fileBase64:st.value.fileBase64
+        fileBase64:st.value.fileBase64,
+        fileName:st.value.fileName
     }
     homeStore.setMyData({act:'gpt.submit', actData:obj });
     mvalue.value='';
     st.value.fileBase64=[];
+    st.value.fileName=[];
     return false;
 }
 const ms= useMessage();
@@ -102,6 +104,7 @@ funt();
                     return ;
                 }
                 st.value.fileBase64.push(d)  
+                st.value.fileName.push(file.name)
             } ).catch(e=>ms.error(e));
         }
     }else{
@@ -117,8 +120,10 @@ funt();
                 ms.info(t('mj.uploadSuccess'));
                 if(r.url.indexOf('http')>-1) {
                     st.value.fileBase64.push(r.url)
+                    st.value.fileName.push(file.name)
                 }else{
                     st.value.fileBase64.push(location.origin +r.url)
+                    st.value.fileName.push(file.name)
                 }
             }else if(r.error) ms.error(r.error);
         }).catch(e=>{

--- a/src/views/mj/mjTextAttr.vue
+++ b/src/views/mj/mjTextAttr.vue
@@ -1,33 +1,71 @@
 <script lang="ts" setup>
-import { localGet } from '@/api';
-import { ref } from 'vue'
-import {NImage} from 'naive-ui'
-import { SvgIcon } from '@/components/common';
+import { localGet } from "@/api";
+import { ref } from "vue";
+import { NImage } from "naive-ui";
+import { SvgIcon } from "@/components/common";
 
+const pp = defineProps<{ image: string }>();
+const images = ref<{ fileName: string; fileBase64: string }[]>([]);
+const files = ref<{ fileName: string; fileBase64: string }[]>([]);
 
-const pp = defineProps<{image:string}>();
-const images =ref([]);
-const load= ()=>{
-    localGet(pp.image).then((r:any)=>{
-        //images.value= JSON.parse(r);
-        if(r){
-           // mlog('load', r); 
-            images.value= JSON.parse(r);
-        }
-    }).catch(e=>{})
-}
-load();
+const isImage = (url) => {
+  const extensions = [".jpeg", ".jpg", ".png", ".gif", ".webp"];
+  url = url.toLowerCase();
+  return extensions.some((ext) => url.endsWith(ext));
+};
+
+const loadImages = async () => {
+  try {
+    const response = await localGet(pp.image);
+    if (response) {
+      const parsedData = JSON.parse(response);
+      if (
+        Array.isArray(parsedData.fileName) &&
+        Array.isArray(parsedData.fileBase64)
+      ) {
+        const combinedData = parsedData.fileName.map(
+          (name: string, index: number) => ({
+            fileName: name,
+            fileBase64: parsedData.fileBase64[index],
+          })
+        );
+
+        images.value = combinedData.filter((file) => isImage(file.fileName));
+        files.value = combinedData.filter((file) => !isImage(file.fileName));
+      }
+    }
+  } catch (error) {
+    console.error("Failed to load images:", error);
+  }
+};
+
+loadImages();
 </script>
+
 <template>
-<div v-if="images.length" class="flex flex-wrap justify-start items-baseline">
-          <div v-for="(img,k ) of  images" :key="k" class="p-1" >
-            <NImage :src="img" preview class=" rounded" :class="[images.length<=1?'w-[330px]':'w-[130px]']" >
-                <template #placeholder>
-                 <a class="w-full h-full flex items-center justify-center  text-neutral-500" :href="img" target="_blank" >
-                    <SvgIcon icon="mdi:download" />{{$t('mjchat.attr')}} {{ k+1 }}
-                </a>
-                </template>
-            </NImage>
-          </div>
-      </div>
+  <div v-if="images.length" class="flex flex-wrap justify-start items-baseline p-1">
+    <div v-for="(img, k) of images" :key="k">
+      <NImage :src="img.fileBase64" preview class="rounded" :class="[images.length <= 1 ? 'w-[330px]' : 'w-[130px]']">
+        <template #placeholder>
+          <a class="w-full h-full flex items-center justify-center text-neutral-500" :href="img.fileBase64"
+            target="_blank">
+            <SvgIcon icon="mdi:download" />{{ img.fileName }}
+          </a>
+        </template>
+      </NImage>
+    </div>
+  </div>
+  <div v-if="files.length" class="block justify-start items-baseline p-1">
+    <div v-for="(file, k) of files" :key="k" :class="[
+      'w-full h-full block items-center text-xs text-neutral-500',
+      { 'mb-1': k !== files.length - 1 },
+    ]">
+      <a :href="file.fileBase64" target="_blank" class="flex items-center">
+        <SvgIcon icon="mdi:download" class="mr-2" />
+        <n-ellipsis style="max-width: 280px">
+          {{ file.fileName }}
+        </n-ellipsis>
+      </a>
+    </div>
+  </div>
 </template>

--- a/src/views/mj/mjTextAttr.vue
+++ b/src/views/mj/mjTextAttr.vue
@@ -45,7 +45,7 @@ loadImages();
 <template>
   <div v-if="images.length" class="flex flex-wrap justify-start items-baseline p-1">
     <div v-for="(img, k) of images" :key="k">
-      <NImage :src="img.fileBase64" preview class="rounded" :class="[images.length <= 1 ? 'w-[330px]' : 'w-[130px]']">
+      <NImage :src="img.fileBase64" preview class="rounded" :class="[images.length <= 1 ? 'w-[250px]' : 'w-[130px]']">
         <template #placeholder>
           <a class="w-full h-full flex items-center justify-center text-neutral-500" :href="img.fileBase64"
             target="_blank">


### PR DESCRIPTION
### 本次PR的目的

原版本上传文件，无法看到文件名，只会显示附件几，觉得不太方便，于是想着自己修改一下，使得能显示文件名！

### PR的内容

修改了文件上传的样式，使得文件和图片分开，文件上面是图片，使得整体结构比较清楚

![image](https://github.com/user-attachments/assets/1574078a-b4ea-45c1-af52-347104431e13)
