### PR TITLE
feat(video): add Atlas Cloud provider

### DIFF
--- a/src/store/homeStore.ts
+++ b/src/store/homeStore.ts
@@ -97,6 +97,8 @@ export const gptConfigStore= reactive({
 export interface gptServerType{
     OPENAI_API_KEY:string
     OPENAI_API_BASE_URL:string
+    ATLAS_SERVER:string
+    ATLAS_KEY:string
     MJ_SERVER:string
     MJ_API_SECRET:string
     UPLOADER_URL:string
@@ -140,6 +142,8 @@ const  getServerDefault=()=>{
 let v:gptServerType={
         OPENAI_API_KEY:'',
         OPENAI_API_BASE_URL:'',
+        ATLAS_SERVER:'https://api.atlascloud.ai/api/v1',
+        ATLAS_KEY:'',
         MJ_SERVER:'',
         UPLOADER_URL:'',
         MJ_API_SECRET:'',

--- a/src/views/mj/aiSetServer.vue
+++ b/src/views/mj/aiSetServer.vue
@@ -84,6 +84,22 @@ watch(() => gptServerStore.myData.OPENAI_API_KEY , (n)=>{
           </n-input>
       </section>
 
+      <div class="text-right">Atlas Cloud</div>
+      <section class="mb-4 flex justify-between items-center">
+          <n-input @blur="blurClean" placeholder="https://api.atlascloud.ai/api/v1" v-model:value="gptServerStore.myData.ATLAS_SERVER" clearable>
+            <template #prefix>
+              <span class="text-[var(--n-tab-text-color-active)]">Atlas API:</span>
+            </template>
+          </n-input>
+      </section>
+      <section class="mb-4 flex justify-between items-center">
+          <n-input @blur="blurClean" type="password" placeholder="Atlas Cloud API Key" show-password-on="click" v-model:value="gptServerStore.myData.ATLAS_KEY" clearable>
+            <template #prefix>
+              <span class="text-[var(--n-tab-text-color-active)]">Atlas Key:</span>
+            </template>
+          </n-input>
+      </section>
+
 
       <div class="flex justify-between items-baseline ">
         <section class="mb-4 flex justify-start items-center">

--- a/src/views/video/tpl.ts
+++ b/src/views/video/tpl.ts
@@ -1,6 +1,29 @@
 export const mytpl={
 "tpl":[
     {
+        "model":"bytedance/seedance-2.0/text-to-video",
+        "plat":"atlas",
+        "field":[
+            {"key":"prompt","type":"textarea","placeholder":"Video Description"},
+            {"key":"duration","type":"select","value":5,"options":[
+                {"label":"Duration: 5s","value":5},
+                {"label":"Duration: 10s","value":10},
+                {"label":"Duration: 15s","value":15}
+            ]},
+            {"key":"resolution","type":"select","value":"720p","options":[
+                {"label":"Resolution: 480p","value":"480p"},
+                {"label":"Resolution: 720p","value":"720p"},
+                {"label":"Resolution: 1080p","value":"1080p"}
+            ]},
+            {"key":"ratio","type":"select","value":"16:9","options":[
+                {"label":"Ratio: 16:9","value":"16:9"},
+                {"label":"Ratio: 9:16","value":"9:16"},
+                {"label":"Ratio: 1:1","value":"1:1"}
+            ]},
+            {"key":"generate_audio","type":"no","value":true}
+        ]
+    },
+    {
         "model":"sora-2",
         "field":[
            {

--- a/src/views/video/veo.ts
+++ b/src/views/video/veo.ts
@@ -1,7 +1,7 @@
 import { gptFetch, gptUploadFile, mlog } from "@/api"
 import { DtoItem, DtoStore } from "@/api/dtoStore"
 import { sleep } from "@/api/suno"
-import { homeStore } from "@/store"
+import { gptServerStore, homeStore } from "@/store"
 
 export interface DtoTpl{
     model:string
@@ -30,6 +30,8 @@ export const PostVideo= async(nowModel:DtoTpl, data:any)=>{
         rz= await googleVeo(nowModel,data)
     }else if(plat=='openai'){
         rz= await openaiVideo(nowModel,data)
+    }else if(plat=='atlas'){
+        rz= await atlasVideo(nowModel,data)
     }else if(plat=='fal-ai'){
         rz= await falAI(nowModel,data)
     }else{
@@ -51,10 +53,66 @@ export const DtoFeed= async (item:DtoItem)=>{
     // }
    if(item.plat=="fal-ai"){
         falAiFeed(item.id)
+    }else if(item.plat=="atlas"){
+        atlasVideoFeed(item.id)
     }else if(item.plat=="openai" ){
      openaiVideoFeed(item.id)
     }else{
       googleVeoFeed(item.id)
+    }
+}
+
+const atlasRequest = async(path:string, init?:RequestInit)=>{
+    const server=gptServerStore.myData.ATLAS_SERVER.replace(/\/+$/, '')
+    const key=gptServerStore.myData.ATLAS_KEY.trim()
+    if(!key) throw new Error('Atlas Cloud API key is required')
+    const response=await fetch(server+path, {
+        ...init,
+        headers:{
+            'Authorization':`Bearer ${key}`,
+            'Content-Type':'application/json',
+            ...init?.headers,
+        },
+    })
+    const body=await response.json()
+    if(!response.ok || (body.code && body.code!==200)) throw new Error(body.message??`Atlas Cloud request failed: ${response.status}`)
+    return body.data
+}
+
+const atlasVideo= async(nowModel:DtoTpl, data:any)=>{
+    const d=await atlasRequest('/model/generateVideo', {
+        method:'POST',
+        body:JSON.stringify({...data, model:nowModel.model}),
+    })
+    if(!d?.id) throw new Error('Atlas Cloud did not return a prediction id')
+    return {
+        mid:d.id,
+        id:d.id,
+        type:'video',
+        plat:nowModel.plat,
+        status:d.status??'submitted',
+        last_feed:Math.floor(Date.now()/1000),
+        title:data.prompt??'no prompt',
+    } as DtoItem
+}
+
+const atlasVideoFeed= async(id:string)=>{
+    for(let i=0;i<120;i++){
+        const rz=csuno.getOneById(id)
+        if(!rz || rz.status==='completed' || rz.status==='failed') return
+        try{
+            const d=await atlasRequest('/model/prediction/'+rz.mid)
+            const output=Array.isArray(d.outputs)?d.outputs[0]:(Array.isArray(d.output)?d.output[0]:d.output)
+            rz.data=d
+            rz.url=typeof output==='string'?output:''
+            rz.status=rz.url?'completed':(d.status??'pending')
+        }catch(error){
+            rz.status='pending'
+        }
+        rz.last_feed=Math.floor(Date.now()/1000)
+        csuno.save(rz)
+        homeStore.setMyData({act:'dtoFeed'})
+        await sleep(5000)
     }
 }
 


### PR DESCRIPTION
## Summary

- add dedicated Atlas Cloud endpoint and API key settings
- add Atlas Seedance 2.0 to the video model selector
- submit Atlas video tasks, poll prediction status, and persist generated video URLs in the existing task history

## Verification

- `pnpm@9.15.9 install --frozen-lockfile`
- `pnpm build` (3168 modules transformed, production PWA build completed)
- confirmed `bytedance/seedance-2.0/text-to-video` in the live Atlas Cloud model catalog
- `pnpm type-check` remains blocked by existing repository-wide TypeScript errors in unrelated files

The contribution guide references a `feature` branch, but that branch is not present in the upstream repository, so this PR targets the current default branch (`main`).
