### PR TITLE
feat: add MuAPI video provider

### DIFF
--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -685,6 +685,8 @@ export const blurClean= ()=>{
   mlog('blurClean');
   gptServerStore.myData.OPENAI_API_BASE_URL =myTrim( myTrim(gptServerStore.myData.OPENAI_API_BASE_URL.trim(),'/'), '\\' );
   gptServerStore.myData.OPENAI_API_KEY = gptServerStore.myData.OPENAI_API_KEY.trim();
+  gptServerStore.myData.MUAPI_SERVER = gptServerStore.myData.MUAPI_SERVER.trim();
+  gptServerStore.myData.MUAPI_KEY = gptServerStore.myData.MUAPI_KEY.trim();
   gptServerStore.myData.MJ_SERVER =myTrim( myTrim( gptServerStore.myData.MJ_SERVER.trim(),'/'),'\\');
   gptServerStore.myData.MJ_API_SECRET = gptServerStore.myData.MJ_API_SECRET.trim();
   gptServerStore.myData.UPLOADER_URL=  myTrim( myTrim( gptServerStore.myData.UPLOADER_URL.trim(),'/'),'\\');

--- a/src/store/homeStore.ts
+++ b/src/store/homeStore.ts
@@ -97,6 +97,8 @@ export const gptConfigStore= reactive({
 export interface gptServerType{
     OPENAI_API_KEY:string
     OPENAI_API_BASE_URL:string
+    MUAPI_SERVER:string
+    MUAPI_KEY:string
     MJ_SERVER:string
     MJ_API_SECRET:string
     UPLOADER_URL:string
@@ -140,6 +142,8 @@ const  getServerDefault=()=>{
 let v:gptServerType={
         OPENAI_API_KEY:'',
         OPENAI_API_BASE_URL:'',
+        MUAPI_SERVER:'https://api.muapi.ai/api/v1',
+        MUAPI_KEY:'',
         MJ_SERVER:'',
         UPLOADER_URL:'',
         MJ_API_SECRET:'',

--- a/src/views/mj/aiSetServer.vue
+++ b/src/views/mj/aiSetServer.vue
@@ -84,6 +84,25 @@ watch(() => gptServerStore.myData.OPENAI_API_KEY , (n)=>{
           </n-input>
       </section>
 
+      <div class="text-right">
+        <a href="https://muapi.ai/ai-video-api" target="_blank" rel="noreferrer">MuAPI video API</a>
+      </div>
+      <section class="mb-4 flex justify-between items-center"  >
+          <n-input @blur="blurClean" placeholder="MuAPI API server" v-model:value="gptServerStore.myData.MUAPI_SERVER" clearable>
+            <template #prefix>
+              <span class="text-[var(--n-tab-text-color-active)]">MuAPI Server:</span>
+            </template>
+          </n-input>
+      </section>
+
+      <section class="mb-4 flex justify-between items-center"  >
+          <n-input @blur="blurClean" type="password" placeholder="MuAPI access key" show-password-on="click" v-model:value="gptServerStore.myData.MUAPI_KEY" clearable>
+            <template #prefix>
+              <span class="text-[var(--n-tab-text-color-active)]"><a href="https://muapi.ai/access-keys" target="_blank" rel="noreferrer">MuAPI Key:</a></span>
+            </template>
+          </n-input>
+      </section>
+
 
       <div class="flex justify-between items-baseline ">
         <section class="mb-4 flex justify-start items-center">

--- a/src/views/video/tpl.ts
+++ b/src/views/video/tpl.ts
@@ -1,6 +1,40 @@
 export const mytpl={
 "tpl":[
     {
+        "model":"seedance-2-text-to-video",
+        "field":[
+            {
+                "key":"prompt",
+                "type":"textarea",
+                "placeholder":"Video Description"
+            },
+            {
+                "key":"aspect_ratio",
+                "type":"select",
+                "value":"16:9",
+                "options":[
+                    { "label":"Ratio 21:9", "value":"21:9"},
+                    { "label":"Ratio 16:9", "value":"16:9"},
+                    { "label":"Ratio 4:3", "value":"4:3"},
+                    { "label":"Ratio 1:1", "value":"1:1"},
+                    { "label":"Ratio 3:4", "value":"3:4"},
+                    { "label":"Ratio 9:16", "value":"9:16"}
+                ]
+            },
+            {
+                "key":"duration",
+                "type":"select",
+                "value":5,
+                "options":[
+                    { "label":"Duration: 5s", "value":5},
+                    { "label":"Duration: 10s", "value":10},
+                    { "label":"Duration: 15s", "value":15}
+                ]
+            }
+        ],
+        "plat":"muapi"
+    },
+    {
         "model":"sora-2",
         "field":[
            {

--- a/src/views/video/veo.ts
+++ b/src/views/video/veo.ts
@@ -1,7 +1,7 @@
 import { gptFetch, gptUploadFile, mlog } from "@/api"
 import { DtoItem, DtoStore } from "@/api/dtoStore"
 import { sleep } from "@/api/suno"
-import { homeStore } from "@/store"
+import { gptServerStore, homeStore } from "@/store"
 
 export interface DtoTpl{
     model:string
@@ -32,6 +32,8 @@ export const PostVideo= async(nowModel:DtoTpl, data:any)=>{
         rz= await openaiVideo(nowModel,data)
     }else if(plat=='fal-ai'){
         rz= await falAI(nowModel,data)
+    }else if(plat=='muapi'){
+        rz= await muapiVideo(nowModel,data)
     }else{
         mlog("plat",plat, "这个平台没有指定")
         return 
@@ -51,8 +53,10 @@ export const DtoFeed= async (item:DtoItem)=>{
     // }
    if(item.plat=="fal-ai"){
         falAiFeed(item.id)
-    }else if(item.plat=="openai" ){
+   }else if(item.plat=="openai" ){
      openaiVideoFeed(item.id)
+    }else if(item.plat=="muapi"){
+     muapiVideoFeed(item.id)
     }else{
       googleVeoFeed(item.id)
     }
@@ -111,6 +115,109 @@ const openaiVideo= async(nowModel:DtoTpl, data:any)=>{
        title:data.prompt??'no prompt'
    }
    return rz
+}
+
+const muapiBaseUrl=()=>{
+    let configured= gptServerStore.myData.MUAPI_SERVER?.trim() || 'https://api.muapi.ai/api/v1'
+    while(configured.endsWith('/')) configured=configured.slice(0,-1)
+    return configured
+}
+
+const muapiJson=async(path:string, key:string, opt:RequestInit={})=>{
+    const headers:Record<string,string>={
+        'Content-Type':'application/json',
+        ...(opt.headers as Record<string,string> || {}),
+        'x-api-key':key
+    }
+    const response= await fetch(muapiBaseUrl()+path, {...opt, headers})
+    const text= await response.text()
+    let body:any={}
+    try {
+        body= text ? JSON.parse(text) : {}
+    } catch {
+        body={detail:text}
+    }
+    if(!response.ok){
+        const message= body.detail??body.message??body.error??('MuAPI request failed ('+response.status+')')
+        throw new Error(String(message))
+    }
+    return body
+}
+
+const muapiVideo= async(nowModel:DtoTpl, data:any)=>{
+    const key= gptServerStore.myData.MUAPI_KEY?.trim()
+    if(!key) throw new Error('MuAPI access key is not configured')
+    if(!data.prompt?.trim()) throw new Error('A video prompt is required')
+    const payload={
+        prompt:data.prompt.trim(),
+        aspect_ratio:data.aspect_ratio || '16:9',
+        duration:Number(data.duration || 5)
+    }
+    const route= encodeURIComponent(nowModel.key??nowModel.model)
+    const d:any= await muapiJson('/'+route, key, {
+        method:'POST',
+        body:JSON.stringify(payload)
+    })
+    const id= d.request_id??d.id??d.prediction_id
+    if(!id) throw new Error('MuAPI did not return a request id')
+    const rz:DtoItem={
+        mid:String(id),
+        id:String(id),
+        type:'video',
+        plat:'muapi',
+        status:d.status??'submitted',
+        last_feed:Math.floor(Date.now() / 1000),
+        title:payload.prompt,
+        data:d
+    }
+    return rz
+}
+
+const collectMuapiUrls=(value:any, result:string[]=[]):string[]=>{
+    if(typeof value==='string'){
+        if(value.indexOf('https://')==0 || value.indexOf('http://')==0) result.push(value)
+        return result
+    }
+    if(Array.isArray(value)){
+        value.forEach(item=> collectMuapiUrls(item,result))
+        return result
+    }
+    if(value && typeof value==='object'){
+        const preferred=['video','video_url','videos','output','outputs','url','urls','result','output_data','images','image']
+        for(const key of preferred){
+            if(key in value) collectMuapiUrls(value[key],result)
+        }
+        for(const [key,item] of Object.entries(value)){
+            if(!preferred.includes(key)) collectMuapiUrls(item,result)
+        }
+    }
+    return result
+}
+
+export const muapiVideoFeed= async(id:string)=>{
+    const key= gptServerStore.myData.MUAPI_KEY?.trim()
+    if(!key) return
+    for(let i=0;i<120;i++){
+        const rz= csuno.getOneById(id)
+        if(!rz) return
+        if(rz.status=='completed'||rz.status=='failed') return
+        try {
+            const d:any= await muapiJson('/predictions/'+encodeURIComponent(rz.mid)+'/result', key)
+            const urls= collectMuapiUrls(d)
+            const terminal= ['failed','error','canceled','cancelled'].includes(String(d.status??'').toLowerCase())
+            rz.data=d
+            rz.url= urls[0]??''
+            rz.status= rz.url?'completed':(terminal?'failed':(d.status??'pending'))
+        } catch (error) {
+            mlog('MuAPI feed error',error)
+            rz.status='pending'
+        }
+        rz.last_feed=Math.floor(Date.now() / 1000)
+        csuno.save(rz)
+        homeStore.setMyData({act:'dtoFeed'})
+        if(rz.status=='completed'||rz.status=='failed') return
+        await sleep(5000)
+    }
 }
 
 const googleVeo= async(nowModel:DtoTpl, data:any)=>{


### PR DESCRIPTION
## Summary

- add an opt-in MuAPI text-to-video provider to the existing video workspace
- add separate MuAPI server/key settings and a Seedance 2 text-to-video preset
- submit jobs, poll bounded result status, and persist completed video URLs in the existing history

## Verification

- `pnpm run build-only`
- `git diff --check`

## Setup

- [MuAPI video API](https://muapi.ai/ai-video-api)
- [MuAPI access keys](https://muapi.ai/access-keys)

MuAPI remains opt-in; existing provider defaults are unchanged.
